### PR TITLE
remove graph filter from academic position sparql because current set…

### DIFF
--- a/src/main/resources/sparql/academic_positions.ssp
+++ b/src/main/resources/sparql/academic_positions.ssp
@@ -3,7 +3,6 @@
 ${include("sparql/prefixes.ssp")}
 
 select ?relationship ?type ?label ?institute ?role {
-  GRAPH ?g {
     ?personUri core:relatedBy ?relationship .
     ?relationship a dukecv:NonDukePosition .
     ?relationship vitro:mostSpecificType ?type .
@@ -11,6 +10,4 @@ select ?relationship ?type ?label ?institute ?role {
     ?relationship dukecv:nonDukeAcademicInstitution ?institute .
     ?relationship dukecv:nonDukeAcademicRole ?role .
     FILTER(?personUri=<${uri}>)
-  }
-  FILTER(?g=<https://vivo.duke.edu/a/graph/AcademicPosition> )
 }


### PR DESCRIPTION
…up (version?) does not appear to support GRAPH syntax. 

There should not actually be any data in another graph anyway,  but acceptance has some errant data I was trying to filter out.