### PR TITLE
FDP-3078 Slight tweak to position sparql

### DIFF
--- a/src/main/resources/sparql/positions.ssp
+++ b/src/main/resources/sparql/positions.ssp
@@ -2,8 +2,8 @@
 <%@ val uri: String = "http://nothing.com" %>
 ${include("sparql/prefixes.ssp")}
 
-SELECT ?uri (MIN(?type) AS ?type) (MIN(?label) AS ?label) (MIN(?rank) AS ?rank) (MIN(?dateUri) AS ?dateUri) 
-  (MIN(?startDatetimeUri) AS ?startDatetimeUri) (MIN(?startYear) AS ?startYear) 
+SELECT ?uri (MIN(?type) AS ?type) (MIN(?label) AS ?label) (MIN(?rank) AS ?rank) (MIN(?dateUri) AS ?dateUri)
+  (MIN(?startDatetimeUri) AS ?startDatetimeUri) (MIN(?startYear) AS ?startYear)
   (MIN(?organizationUri) AS ?organizationUri) (MIN(?organizationLabel) AS ?organizationLabel)
   (MIN(?schoolUri) AS ?schoolUri) (MIN(?schoolLabel) AS ?schoolLabel)
   (MIN(?endDatetimeUri) AS ?endDatetimeUri) (MIN(?endYear) AS ?endYear)
@@ -19,18 +19,19 @@ WHERE
 
   ?organizationUri rdfs:label ?organizationLabel .
 
-  ?organizationUri obo:BFO_0000050* ?schoolUri. 
-  ?schoolUri vitro:mostSpecificType core:School; rdfs:label ?schoolLabel. 
-  FILTER (?schoolUri NOT IN (<https://scholars.duke.edu/individual/org50000021>)) 
-    
+  ?organizationUri obo:BFO_0000050* ?schoolUri.
+  ?schoolUri vitro:mostSpecificType core:School; rdfs:label ?schoolLabel.
+  FILTER (?schoolUri NOT IN (<https://scholars.duke.edu/individual/org50000021>))
+
 
   OPTIONAL {
-  ?uri core:dateTimeInterval ?dateUri .
-  ?dateUri core:start ?startDatetimeUri . 
-  ?startDatetimeUri core:dateTime ?startYear .
+    ?uri core:dateTimeInterval ?dateUri .
+    ?dateUri core:start ?startDatetimeUri .
+    ?startDatetimeUri core:dateTime ?startYear .
   }
   OPTIONAL {
-    ?dateUri core:end ?endDatetimeUri . 
+    ?uri core:dateTimeInterval ?endDateUri .
+    ?endDateUri core:end ?endDatetimeUri .
     ?endDatetimeUri core:dateTime ?endYear .
   }
   ?uri core:rank ?rank .


### PR DESCRIPTION
For users with no start or end, the end date with being populated with:
 endYear: "0199-01-01T00:00:00"

I think this was matching a null value for the dateUri.  This change will match the end date.