### PR TITLE
FDP-3255 Add field to use as date >>> master

### DIFF
--- a/src/main/scala/models/Newsfeed.scala
+++ b/src/main/scala/models/Newsfeed.scala
@@ -14,6 +14,10 @@ case class Newsfeed(uri:String,
     uri :: super.uris
   }
 
+  override def officialDateKey = {
+    "newsDatetime"
+  }
+
 }
 
 object Newsfeed extends AttributeParams {


### PR DESCRIPTION
Looks like news using as different field name. We need to override
 the field name to use the new date.