### PR TITLE
move 'category' out of start/end date optional

### DIFF
--- a/src/main/resources/sparql/past_appointments.ssp
+++ b/src/main/resources/sparql/past_appointments.ssp
@@ -20,6 +20,6 @@ WHERE
     ?startDatetimeUri core:dateTime ?startYear .
     ?dateUri core:end ?endDatetimeUri . 
     ?endDatetimeUri core:dateTime ?endYear .
-    ?uri vcard:category ?appointmentTypeCode . 
   }
+  OPTIONAL { ?uri vcard:category ?appointmentTypeCode . } 
 }


### PR DESCRIPTION
it looks to be leaving off dates if 'category' not found

Going to go ahead and merge since it's one line - and an experiment (testing on single record in acceptance now)