### PR TITLE
Indexer fail

### DIFF
--- a/src/main/scala/solr/VivoSolrIndexer.scala
+++ b/src/main/scala/solr/VivoSolrIndexer.scala
@@ -68,7 +68,7 @@ class VivoSolrIndexer(vivo: Vivo, solr: SolrServer)
     }
     future onFailure {
       case exception => {
-        log.info("FAILURE indexing people and organizations" + exception.getMessage)
+        log.info("FAILURE indexing people and organizations:" + exception.getMessage)
       }
     }
     Await.ready(future, Duration(22, HOURS))

--- a/src/main/scala/solr/VivoSolrIndexer.scala
+++ b/src/main/scala/solr/VivoSolrIndexer.scala
@@ -68,7 +68,7 @@ class VivoSolrIndexer(vivo: Vivo, solr: SolrServer)
     }
     future onFailure {
       case exception => {
-        log.info("FAILURE indexing people and organizations ${exception.getMessage}")
+        log.info("FAILURE indexing people and organizations" + exception.getMessage)
       }
     }
     Await.ready(future, Duration(22, HOURS))


### PR DESCRIPTION
NOTE: doesn't actually support string interpolation - so it just printed "${exception.getMessage}" literally